### PR TITLE
feat: add Dockerized Appium setup with docker-compose and Dockerfile …

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+target/
+test-output/
+.git/
+.github/
+*.md
+*.ps1
+nul
+.idea/
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Test Runner Dockerfile
+# Builds the Maven project and runs tests against the Dockerized Appium server
+
+FROM maven:3.9-eclipse-temurin-11 AS builder
+
+WORKDIR /app
+
+# Copy POM first to cache dependencies
+COPY pom.xml .
+RUN mvn dependency:resolve -B
+
+# Copy all project sources
+COPY src/ src/
+COPY config/ config/
+COPY apps/ apps/
+COPY testng.xml .
+
+# Compile the project
+RUN mvn compile test-compile -B
+
+# Run tests (entry point)
+# The APPIUM_HOST env variable is set by docker-compose
+CMD ["mvn", "test", "-B"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Test Runner Dockerfile
 # Builds the Maven project and runs tests against the Dockerized Appium server
 
-FROM maven:3.9-eclipse-temurin-11 AS builder
+FROM maven:3.9-eclipse-temurin-11
 
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+version: "3.8"
+
+# Dockerized Appium Setup for Mobile Test Automation (Bonus)
+# Uses budtmo/docker-android which includes Android emulator + Appium server
+
+services:
+  # Android emulator with Appium server
+  appium:
+    image: budtmo/docker-android:emulator_12.0
+    container_name: android-appium
+    privileged: true
+    ports:
+      - "4723:4723"   # Appium server
+      - "6080:6080"   # noVNC (browser-based screen viewer)
+      - "5554:5554"   # ADB
+      - "5555:5555"   # ADB
+    environment:
+      EMULATOR_DEVICE: "Samsung Galaxy S10"
+      WEB_VNC: "true"
+      APPIUM: "true"
+      APPIUM_HOST: "0.0.0.0"
+      APPIUM_PORT: "4723"
+      EMULATOR_NAME: "android-emulator"
+      DATAPARTITION: "2g"
+    volumes:
+      - ./apps:/root/tmp/apps     # Mount APK folder into the container
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:4723/status || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 20
+      start_period: 120s
+    deploy:
+      resources:
+        limits:
+          memory: 4g
+        reservations:
+          memory: 2g
+
+  # Test runner service - builds and runs tests against the Appium container
+  tests:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: test-runner
+    depends_on:
+      appium:
+        condition: service_healthy
+    environment:
+      APPIUM_HOST: appium
+      APPIUM_PORT: 4723
+    volumes:
+      - ./test-output:/app/test-output         # ExtentReports output
+      - ./target:/app/target                   # Maven target (surefire reports)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,12 +30,6 @@ services:
       timeout: 10s
       retries: 20
       start_period: 120s
-    deploy:
-      resources:
-        limits:
-          memory: 4g
-        reservations:
-          memory: 2g
 
   # Test runner service - builds and runs tests against the Appium container
   tests:

--- a/src/main/java/com/automation/base/BaseTest.java
+++ b/src/main/java/com/automation/base/BaseTest.java
@@ -24,6 +24,15 @@ public class BaseTest {
         String appPath      = AppiumUtils.getProperty("app.path");
         String automationName = AppiumUtils.getProperty("automation.name");
 
+        // Docker support: override Appium URL from environment variables
+        String appiumHost = System.getenv("APPIUM_HOST");
+        String appiumPort = System.getenv("APPIUM_PORT");
+        if (appiumHost != null && !appiumHost.isEmpty()) {
+            appiumUrl = "http://" + appiumHost + ":" +
+                    (appiumPort != null ? appiumPort : "4723");
+            System.out.println("Using Docker Appium URL: " + appiumUrl);
+        }
+
         // Configure desired capabilities
         UiAutomator2Options options = new UiAutomator2Options();
         options.setPlatformName(platformName);

--- a/src/main/java/com/automation/base/BaseTest.java
+++ b/src/main/java/com/automation/base/BaseTest.java
@@ -27,9 +27,16 @@ public class BaseTest {
         // Docker support: override Appium URL from environment variables
         String appiumHost = System.getenv("APPIUM_HOST");
         String appiumPort = System.getenv("APPIUM_PORT");
-        if (appiumHost != null && !appiumHost.isEmpty()) {
-            appiumUrl = "http://" + appiumHost + ":" +
-                    (appiumPort != null ? appiumPort : "4723");
+        if (appiumHost != null && !appiumHost.trim().isEmpty()) {
+            int appiumPortNumber = 4723;
+            if (appiumPort != null && !appiumPort.trim().isEmpty()) {
+                try {
+                    appiumPortNumber = Integer.parseInt(appiumPort.trim());
+                } catch (NumberFormatException e) {
+                    System.out.println("Invalid APPIUM_PORT '" + appiumPort + "', defaulting to 4723");
+                }
+            }
+            appiumUrl = "http://" + appiumHost.trim() + ":" + appiumPortNumber;
             System.out.println("Using Docker Appium URL: " + appiumUrl);
         }
 


### PR DESCRIPTION
…(Bonus)

- Added docker-compose.yml with budtmo/docker-android emulator + Appium server
- Added Dockerfile for Maven test runner container
- Added .dockerignore to optimize Docker build context
- Updated BaseTest.java to support APPIUM_HOST/APPIUM_PORT env variables for Docker
- Updated README.md with Docker setup instructions and architecture diagram
- noVNC support at http://localhost:6080 for emulator screen viewing
- Health checks ensure tests wait until Appium is ready